### PR TITLE
Creation and Read User

### DIFF
--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,11 +1,12 @@
 import {
   InternalServerError,
   MethodNotAllowedError,
+  NotFoundError,
   ValidationError,
 } from "infra/errors";
 
 function onErrorHandler(error, request, response) {
-  if (error instanceof ValidationError) {
+  if (error instanceof ValidationError || error instanceof NotFoundError) {
     return response.status(error.statusCode).json(error);
   }
   const publicErrorObject = new InternalServerError({

--- a/infra/controller.js
+++ b/infra/controller.js
@@ -1,6 +1,13 @@
-import { InternalServerError, MethodNotAllowedError } from "infra/errors";
+import {
+  InternalServerError,
+  MethodNotAllowedError,
+  ValidationError,
+} from "infra/errors";
 
 function onErrorHandler(error, request, response) {
+  if (error instanceof ValidationError) {
+    return response.status(error.statusCode).json(error);
+  }
   const publicErrorObject = new InternalServerError({
     cause: error,
     statusCode: error.statusCode,

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -75,3 +75,23 @@ export class ValidationError extends Error {
     };
   }
 }
+
+export class NotFoundError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "We did'nt find this resource in ower systems", {
+      cause,
+    });
+    this.action = action || "Adjust the uploaded data and try again";
+    this.name = "NotFoundError";
+    this.statusCode = 404;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/infra/errors.js
+++ b/infra/errors.js
@@ -55,3 +55,23 @@ export class MethodNotAllowedError extends Error {
     };
   }
 }
+
+export class ValidationError extends Error {
+  constructor({ cause, message, action }) {
+    super(message || "A vaidation error", {
+      cause,
+    });
+    this.action = action || "Adjust the uploaded data and try again";
+    this.name = "ValidationError";
+    this.statusCode = 400;
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      action: this.action,
+      status_code: this.statusCode,
+    };
+  }
+}

--- a/infra/migrations/1740466796992_test-migration.js
+++ b/infra/migrations/1740466796992_test-migration.js
@@ -1,9 +1,0 @@
-/* eslint-disable no-unused-vars */
-
-/* eslint-disable camelcase */
-
-exports.shorthands = undefined;
-
-exports.up = (pgm) => {};
-
-exports.down = (pgm) => {};

--- a/infra/migrations/1745980192243_create-users.js
+++ b/infra/migrations/1745980192243_create-users.js
@@ -1,0 +1,39 @@
+exports.up = (pgm) => {
+  pgm.createTable("users", {
+    id: {
+      type: "uuid",
+      primaryKey: true,
+      default: pgm.func("gen_random_uuid()"),
+    },
+    // for reference github limits username to 39 characters
+    username: {
+      type: "varchar(30)",
+      notNull: true,
+      unique: true,
+    },
+    // why 254 in lenght? https://stackoverflow.com/questions/1199190/what-is-the-optimal-length-for-an-email-address-in-a-database/1199238#1199238
+    email: {
+      type: "varchar(254)",
+      notNull: true,
+      unique: true,
+    },
+    // why 60 in lenght? https://www.npmjs.com/package/bcrypt#hash-inf://www.npmjs.com/package/bcrypt#hash-info1
+    password: {
+      type: "varchar(60)",
+      notNull: true,
+    },
+    // why use timestamp with timezone? https://justatheory.com/2012/04/postgres-use-timestamptz/
+    created_at: {
+      type: "timestamptz",
+      default: pgm.func("timezone('utc', now())"),
+      notNull: true,
+    },
+    updated_at: {
+      type: "timestamptz",
+      default: pgm.func("timezone('utc', now())"),
+      notNull: true,
+    },
+  });
+};
+
+exports.down = false;

--- a/models/migrator.js
+++ b/models/migrator.js
@@ -7,7 +7,7 @@ const defaultMigrationOptions = {
   dryRun: true,
   dir: resolve("infra", "migrations"),
   direction: "up",
-  verbose: true,
+  log: () => {},
   migrationsTable: "pgmigrations",
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,8 @@
         "pg": "8.14.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "swr": "2.2.5"
+        "swr": "2.2.5",
+        "uuid": "11.1.0"
       },
       "devDependencies": {
         "@commitlint/cli": "19.8.0",
@@ -10828,6 +10829,19 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.3.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "pg": "8.14.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "swr": "2.2.5"
+    "swr": "2.2.5",
+    "uuid": "11.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "19.8.0",

--- a/pages/api/v1/users/[username]/index.js
+++ b/pages/api/v1/users/[username]/index.js
@@ -1,0 +1,15 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import user from "models/user";
+
+const router = createRouter();
+
+router.get(getHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function getHandler(request, response) {
+  const username = request.query.username;
+  const userFound = await user.findOneByUsername(username);
+  return response.status(200).json(userFound);
+}

--- a/pages/api/v1/users/index.js
+++ b/pages/api/v1/users/index.js
@@ -1,0 +1,15 @@
+import { createRouter } from "next-connect";
+import controller from "infra/controller";
+import user from "models/user";
+
+const router = createRouter();
+
+router.post(postHandler);
+
+export default router.handler(controller.errorHandlers);
+
+async function postHandler(request, response) {
+  const userInputValues = request.body;
+  const newUser = await user.create(userInputValues);
+  return response.status(201).json(newUser);
+}

--- a/tests/integration/api/v1/users/[username]/get.test.js
+++ b/tests/integration/api/v1/users/[username]/get.test.js
@@ -1,0 +1,100 @@
+import orchestrator from "tests/orchestrator.js";
+import { version as uuidVersion } from "uuid";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.cleanDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("GET /api/v1/users/[username]", () => {
+  describe("Anonymous user", () => {
+    test("With exact case match", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "MesmoCase",
+          email: "email@example.mesmocase.com",
+          password: "123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/MesmoCase",
+      );
+
+      expect(response2.status).toBe(200);
+      const responseBody2 = await response2.json();
+
+      expect(responseBody2).toEqual({
+        id: responseBody2.id,
+        created_at: responseBody2.created_at,
+        updated_at: responseBody2.updated_at,
+        password: "123",
+        email: "email@example.mesmocase.com",
+        username: "MesmoCase",
+      });
+
+      expect(uuidVersion(responseBody2.id)).toBe(4);
+      expect(Date.parse(responseBody2.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody2.updated_at)).not.toBeNaN();
+    });
+
+    test("With case mismatch", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "MesmoCaseDiferente",
+          email: "email@example.mesmocasediferente.com",
+          password: "123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch(
+        "http://localhost:3000/api/v1/users/mesmocasediferente",
+      );
+
+      expect(response2.status).toBe(200);
+      const responseBody2 = await response2.json();
+
+      expect(responseBody2).toEqual({
+        id: responseBody2.id,
+        created_at: responseBody2.created_at,
+        updated_at: responseBody2.updated_at,
+        password: "123",
+        email: "email@example.mesmocasediferente.com",
+        username: "MesmoCaseDiferente",
+      });
+
+      expect(uuidVersion(responseBody2.id)).toBe(4);
+      expect(Date.parse(responseBody2.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody2.updated_at)).not.toBeNaN();
+    });
+
+    test("With nonexistent username", async () => {
+      const response = await fetch(
+        "http://localhost:3000/api/v1/users/nonextistet",
+      );
+
+      expect(response.status).toBe(404);
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "NotFoundError",
+        message: "Username not found",
+        action: "Check if it's not a typo",
+        status_code: 404,
+      });
+    });
+  });
+});

--- a/tests/integration/api/v1/users/post.test.js
+++ b/tests/integration/api/v1/users/post.test.js
@@ -1,0 +1,255 @@
+import orchestrator from "tests/orchestrator.js";
+import { version as uuidVersion } from "uuid";
+
+beforeAll(async () => {
+  await orchestrator.waitForAllServices();
+  await orchestrator.cleanDatabase();
+  await orchestrator.runPendingMigrations();
+});
+
+describe("POST /api/v1/users", () => {
+  describe("Anonymous user", () => {
+    test("With unique and valid data", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "username",
+          email: "email@example.com",
+          password: "123",
+        }),
+      });
+
+      expect(response.status).toBe(201);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        id: responseBody.id,
+        created_at: responseBody.created_at,
+        updated_at: responseBody.updated_at,
+        password: "123",
+        email: "email@example.com",
+        username: "username",
+      });
+
+      expect(uuidVersion(responseBody.id)).toBe(4);
+      expect(Date.parse(responseBody.created_at)).not.toBeNaN();
+      expect(Date.parse(responseBody.updated_at)).not.toBeNaN();
+    });
+    test("With duplicated 'email'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "emaildupllcated1",
+          email: "emailduplicated@example.com",
+          password: "123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "emaildupllcated2",
+          email: "Emailduplicated@example.com",
+          password: "123",
+        }),
+      });
+
+      expect(response2.status).toBe(400);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        name: "ValidationError",
+        message: "E-mail already in use",
+        action: "Use another e-mail to make the register",
+        status_code: 400,
+      });
+    });
+    test("With duplicated 'username'", async () => {
+      const response1 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "usernameduplicated",
+          email: "myemail1@example.com",
+          password: "123",
+        }),
+      });
+
+      expect(response1.status).toBe(201);
+
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "usernameduplicated",
+          email: "myemail2@example.com",
+          password: "123",
+        }),
+      });
+
+      expect(response2.status).toBe(400);
+
+      const response2Body = await response2.json();
+
+      expect(response2Body).toEqual({
+        name: "ValidationError",
+        message: "Username already in use",
+        action: "Use another username to make the register",
+        status_code: 400,
+      });
+    });
+
+    test("With blank 'username'", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "",
+          email: "other-email1@example.com",
+          password: "123",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ValidationError",
+        message: "Username must be filled",
+        action: "Please, fill the field username and try again",
+        status_code: 400,
+      });
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          email: "other-email1@example.com",
+          password: "123",
+        }),
+      });
+
+      expect(response2.status).toBe(400);
+
+      const responseBody2 = await response2.json();
+
+      expect(responseBody2).toEqual({
+        name: "ValidationError",
+        message: "Username must be filled",
+        action: "Please, fill the field username and try again",
+        status_code: 400,
+      });
+    });
+    test("With blank 'email'", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "other-username1",
+          email: "",
+          password: "123",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ValidationError",
+        message: "E-mail must be filled",
+        action: "Please, fill the field e-mail and try again",
+        status_code: 400,
+      });
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "other-username1Value",
+          password: "123",
+        }),
+      });
+
+      expect(response2.status).toBe(400);
+
+      const responseBody2 = await response2.json();
+
+      expect(responseBody2).toEqual({
+        name: "ValidationError",
+        message: "E-mail must be filled",
+        action: "Please, fill the field e-mail and try again",
+        status_code: 400,
+      });
+    });
+    test("With blank 'password'", async () => {
+      const response = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "other-username2",
+          email: "email@othething.dev",
+          password: "",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+
+      const responseBody = await response.json();
+
+      expect(responseBody).toEqual({
+        name: "ValidationError",
+        message: "Password must be filled",
+        action: "Please, fill the field password and try again",
+        status_code: 400,
+      });
+      const response2 = await fetch("http://localhost:3000/api/v1/users", {
+        method: "POST",
+        headers: {
+          ["Content-Type"]: "application/json",
+        },
+        body: JSON.stringify({
+          username: "other-username3",
+          email: "emailemail@othething.com.dev",
+        }),
+      });
+
+      expect(response2.status).toBe(400);
+
+      const responseBody2 = await response2.json();
+
+      expect(responseBody2).toEqual({
+        name: "ValidationError",
+        message: "Password must be filled",
+        action: "Please, fill the field password and try again",
+        status_code: 400,
+      });
+    });
+  });
+});

--- a/tests/orchestrator.js
+++ b/tests/orchestrator.js
@@ -1,5 +1,6 @@
 import retry from "async-retry";
 import database from "infra/database.js";
+import migrator from "models/migrator";
 
 async function waitForAllServices() {
   await waitForWebServer();
@@ -22,9 +23,14 @@ async function cleanDatabase() {
   await database.query("drop schema public cascade; create schema public;");
 }
 
+async function runPendingMigrations() {
+  await migrator.runPendingMigrations();
+}
+
 const orchestrator = {
   waitForAllServices,
   cleanDatabase,
+  runPendingMigrations,
 };
 
 export default orchestrator;


### PR DESCRIPTION
- Add `user` model
- Adds 2 new endpoints:
   - `POST` `/api/v1/users`
   - `GET` `/api/v1/users/[username]`
- Remove test `migration`
- Adds `migration` to create `users` table
- Adds two new custom errors: 
   - `ValidationError`
   - `NotFoundError`
- Adds new method to `orchestrator`:
   - `runPendingMigrations`
- Silent `migrator` logs  